### PR TITLE
Harvest the categorical power in `CellCollection.save_sonata`

### DIFF
--- a/voxcell/cell_collection.py
+++ b/voxcell/cell_collection.py
@@ -372,20 +372,22 @@ class CellCollection:
             group = population.create_group('0')
             str_dt = h5py.special_dtype(vlen=str)
             for name, series in self.properties.items():
-                values = series.to_numpy()
                 if name.startswith(self.SONATA_DYNAMIC_PROPERTY):
                     name = name.split(self.SONATA_DYNAMIC_PROPERTY)[1]
                     dt = str_dt if series.dtype == object else series.dtype
-                    group.create_dataset(f'dynamics_params/{name}', data=values, dtype=dt)
+                    group.create_dataset(f'dynamics_params/{name}', data=series.to_numpy(), dtype=dt)
                 elif _is_string_enum(series) or (series.dtype == object and name in forced_library):
-                    unique_values, indices = np.unique(values, return_inverse=True)
-                    if name in forced_library or len(unique_values) < .5 * len(values):
+
+                    indices, unique_index = series.factorize()
+                    unique_values = unique_index.to_numpy()
+
+                    if name in forced_library or len(unique_values) < .5 * len(indices):
                         group.create_dataset(name, data=indices.astype(np.uint32))
                         group.create_dataset(f'@library/{name}', data=unique_values, dtype=str_dt)
                     else:
-                        group.create_dataset(name, data=values, dtype=str_dt)
+                        group.create_dataset(name, data=series.to_numpy(), dtype=str_dt)
                 else:
-                    group.create_dataset(name, data=values)
+                    group.create_dataset(name, data=series.to_numpy())
 
             if self.orientations is not None:
                 if self.orientation_format == "quaternions":

--- a/voxcell/cell_collection.py
+++ b/voxcell/cell_collection.py
@@ -375,7 +375,11 @@ class CellCollection:
                 if name.startswith(self.SONATA_DYNAMIC_PROPERTY):
                     name = name.split(self.SONATA_DYNAMIC_PROPERTY)[1]
                     dt = str_dt if series.dtype == object else series.dtype
-                    group.create_dataset(f'dynamics_params/{name}', data=series.to_numpy(), dtype=dt)
+                    group.create_dataset(
+                        f'dynamics_params/{name}',
+                        data=series.to_numpy(),
+                        dtype=dt,
+                    )
                 elif _is_string_enum(series) or (series.dtype == object and name in forced_library):
                     indices, unique_values = series.factorize()
                     if name in forced_library or len(unique_values) < .5 * len(indices):

--- a/voxcell/cell_collection.py
+++ b/voxcell/cell_collection.py
@@ -377,10 +377,7 @@ class CellCollection:
                     dt = str_dt if series.dtype == object else series.dtype
                     group.create_dataset(f'dynamics_params/{name}', data=series.to_numpy(), dtype=dt)
                 elif _is_string_enum(series) or (series.dtype == object and name in forced_library):
-
-                    indices, unique_index = series.factorize()
-                    unique_values = unique_index.to_numpy()
-
+                    indices, unique_values = series.factorize()
                     if name in forced_library or len(unique_values) < .5 * len(indices):
                         group.create_dataset(name, data=indices.astype(np.uint32))
                         group.create_dataset(f'@library/{name}', data=unique_values, dtype=str_dt)

--- a/voxcell/nexus/voxelbrain.py
+++ b/voxcell/nexus/voxelbrain.py
@@ -22,7 +22,7 @@ def _download_file(url, filepath, overwrite, allow_empty=False):
 
     tmp_filepath = filepath + ".download"
     try:
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=None)
         resp.raise_for_status()
         if not (allow_empty or resp.content):
             raise VoxcellError("Empty content")
@@ -131,7 +131,7 @@ class VoxelBrainAtlas(Atlas):
         """Init VoxelBrainAtlas."""
         super().__init__()
         self._url = url.rstrip("/")
-        resp = requests.get(self._url)
+        resp = requests.get(self._url, timeout=None)
         resp.raise_for_status()
         atlas_id = resp.json()[0]['id']
         assert self._url.endswith(atlas_id)
@@ -141,7 +141,7 @@ class VoxelBrainAtlas(Atlas):
 
     def fetch_data(self, data_type):
         """Fetch `data_type` NRRD."""
-        resp = requests.get(self._url + "/data")
+        resp = requests.get(self._url + "/data", timeout=None)
         resp.raise_for_status()
         data_types = []
         for item in resp.json():

--- a/voxcell/region_map.py
+++ b/voxcell/region_map.py
@@ -138,7 +138,7 @@ class RegionMap:
         """
         ret = pd.DataFrame.from_dict(self._data, orient='index').set_index('id')
         parents = {k: v if v is not None else -1 for k, v in self._parent.items()}
-        ret['parent_id'] = pd.DataFrame.from_dict(parents, orient='index')
+        ret.loc[:, 'parent_id'] = pd.DataFrame.from_dict(parents, orient='index')
         return ret
 
     def _get(self, _id, attr):


### PR DESCRIPTION
Use `pandas.factorize` to make use of categorical columns and avoid sorting/unique on them.
Pandas factorize also doesn't perform by default sorting compared to `numpy.unique`.


Benchmarks:
----
**Test dataset with categorical columns (N >> M):**
```
         morph_class region  layer synapse_class      etype      mtype
0                PYR    AAA      1           EXC  GEN_etype  GEN_mtype
1                PYR    AAA      1           EXC  GEN_etype  GEN_mtype
2                PYR    AAA      1           EXC  GEN_etype  GEN_mtype
3                PYR    AAA      1           EXC  GEN_etype  GEN_mtype
4                PYR    AAA      1           EXC  GEN_etype  GEN_mtype
...              ...    ...    ...           ...        ...        ...
74129106         INT      y      1           INH  GIN_etype  GIN_mtype
74129107         INT      y      1           INH  GIN_etype  GIN_mtype
74129108         INT      y      1           INH  GIN_etype  GIN_mtype
74129109         INT      y      1           INH  GIN_etype  GIN_mtype
74129110         INT      y      1           INH  GIN_etype  GIN_mtype

[74129111 rows x 6 columns]

```
Before:
```
cProfile.run("v.save_sonata('old.h5')", sort="tottime")
         1841 function calls (1820 primitive calls) in 165.646 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        5  149.990   29.998  149.990   29.998 {method 'argsort' of 'numpy.ndarray' objects}
        5    6.121    1.224  158.594   31.719 arraysetops.py:323(_unique1d)
```
After:
```
cProfile.run("v.save_sonata('new.h5')", sort="tottime")
         3616 function calls (3565 primitive calls) in 3.849 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       15    1.929    0.129    1.930    0.129 dataset.py:36(make_new_dset)
        4    1.213    0.303    1.213    0.303 {method 'factorize' of 'pandas._libs.hashtable.Int8HashTable' objects}
        1    0.321    0.321    0.321    0.321 {method 'factorize' of 'pandas._libs.hashtable.Int16HashTable' objects}
```
**Test dataset with 200M unique strings (N=M):**
```python
import voxcell
v = voxcell.CellCollection("test")
v.add_properties({"myprop": [str(u) for u in range(200_000_000)]})
```
Before:
```
cProfile.run("v.save_sonata('old.h5')", sort="tottime")
         259 function calls (252 primitive calls) in 204.472 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1  111.898  111.898  111.898  111.898 {method 'argsort' of 'numpy.ndarray' objects}
        2   55.541   27.770   64.819   32.409 dataset.py:36(make_new_dset)
        1   13.771   13.771  204.472  204.472 <string>:1(<module>)
```
After:
```
cProfile.run("v.save_sonata('new.h5')", sort="tottime")
         486 function calls (478 primitive calls) in 159.944 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1   86.519   86.519   86.519   86.519 {method 'factorize' of 'pandas._libs.hashtable.StringHashTable' objects}
        2   54.228   27.114   63.130   31.565 dataset.py:36(make_new_dset)
        1    8.902    8.902    8.902    8.902 base.py:60(<setcomp>)
```

For completeness, I also checked how the sort flag in `factorize` affects the times.
In the case of already categorized columns, the time difference is not significant. However, in the case of a list of unique strings the time is significantly higher when `sort=True`:
```
cProfile.run("v.save_sonata('test3.h5')", sort="tottime")
         566 function calls (557 primitive calls) in 387.856 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2  151.046   75.523  160.234   80.117 dataset.py:36(make_new_dset)
        2  142.137   71.068  142.137   71.068 {method 'argsort' of 'numpy.ndarray' objects}
        1   66.579   66.579   66.579   66.579 {method 'factorize' of 'pandas._libs.hashtable.StringHashTable' objects}

```