### PR TITLE
Ensure bbox is correct for negative voxel dimensions

### DIFF
--- a/tests/test_voxel_data.py
+++ b/tests/test_voxel_data.py
@@ -370,3 +370,17 @@ def test_offset_and_voxel_dimensions_type():
 
     voxel_data = test_module.VoxelData(np.ones((2, 2, 2)), voxel_dimensions=(3, 4, 5))
     assert voxel_data.offset.dtype == np.float32
+
+
+def test_VoxelData_negative_voxel_dimensions():
+    """
+    Test VoxelData robustness when negative voxel dimensions are given.
+
+    There is a use case where a different atlas coordinate system is encoded into the voxel
+    dimensions and offset using negative values. The Paxinos atlas 
+    """
+    voxel_data = test_module.VoxelData(np.ones((2, 2, 2)), offset=(1, 2, 3), voxel_dimensions=(1, 1, -1))
+
+    bbox = voxel_data.bbox
+
+    assert_array_equal(bbox, ((1., 2., 1.), (3., 4., 1.)))

--- a/tests/test_voxel_data.py
+++ b/tests/test_voxel_data.py
@@ -377,7 +377,7 @@ def test_VoxelData_negative_voxel_dimensions():
     Test VoxelData robustness when negative voxel dimensions are given.
 
     There is a use case where a different atlas coordinate system is encoded into the voxel
-    dimensions and offset using negative values. The Paxinos atlas 
+    dimensions and offset using negative values. The Paxinos atlas is such an example.
     """
     voxel_data = test_module.VoxelData(np.ones((2, 2, 2)), offset=(1, 2, 3), voxel_dimensions=(1, 1, -1))
 

--- a/tests/test_voxel_data.py
+++ b/tests/test_voxel_data.py
@@ -383,4 +383,4 @@ def test_VoxelData_negative_voxel_dimensions():
 
     bbox = voxel_data.bbox
 
-    assert_array_equal(bbox, ((1., 2., 1.), (3., 4., 1.)))
+    assert_array_equal(bbox, ((1., 2., 1.), (3., 4., 3.)))

--- a/voxcell/voxel_data.py
+++ b/voxcell/voxel_data.py
@@ -76,8 +76,11 @@ class VoxelData:
     @property
     def bbox(self):
         """Bounding box."""
-        return np.array([self.offset,
-                         self.offset + self.voxel_dimensions * self.shape])
+        ret = np.array([self.offset,
+                        self.offset + self.voxel_dimensions * self.shape])
+        # Sort along columns to ensure that min and max points have the
+        # correct order even in edge cases where the voxel dim is negative.
+        return np.sort(ret, axis=0)
 
     @classmethod
     def load_nrrd(cls, nrrd_path):


### PR DESCRIPTION
For certain atlases (e.g. Paxinos) there is a convention of initializing the VoxelData with a negative z voxel dimension.

When the bbox is calculated in that case the min and max point are swapped. This change ensures that under all cases the min an max points are correctly ordered.