### PR TITLE
Switch hemisphere constants to be in line with AIBS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 3.1.4
+-------------
+- switch hemisphere constants to be in line with Allen Institute
+
 Version 3.1.3
 -------------
 - Add a RegionMap conversion to Pandas DataFrame (#6)

--- a/doc/source/scalar.rst
+++ b/doc/source/scalar.rst
@@ -7,7 +7,7 @@ Scalar value image includes the following data types:
 - brain_region: label image with integer values as voxel type
 - gray_level: raw imaging data, integer or float values as voxel type
 - longitude: computed depth information of the atlas, integer values as voxel type
-- hemisphere: hemisphere dataset with int8 or uint8 values as voxel type (0: undefined, 1: right, 2: left)
+- hemisphere: hemisphere dataset with int8 or uint8 values as voxel type (0: undefined, 1: left, 2: right)
 
 .. bbp_table_section:: Specification
     :description:

--- a/tests/test_voxel_data.py
+++ b/tests/test_voxel_data.py
@@ -334,7 +334,7 @@ def test_values_to_hemisphere():
     values = np.array([2, 1, 1, 2])
     actual = test_module.values_to_hemisphere(values)
     assert np.issubdtype(actual.dtype, str)
-    assert_array_equal(actual, ["left", "right", "right", "left"])
+    assert_array_equal(actual, ["right", "left", "left", "right"])
 
 
 def test_values_to_hemisphere_raises_invalid_value():

--- a/voxcell/traits.py
+++ b/voxcell/traits.py
@@ -74,7 +74,7 @@ class SpatialDistribution:
         chosen_trait_indices = np.ones_like(dist_id_per_position, dtype=np.int32) * -1
 
         unique_dists = np.unique(dist_id_per_position[valid])
-        for dist_id, dist in self.distributions[unique_dists].iteritems():
+        for dist_id, dist in self.distributions[unique_dists].items():
             hit_count = np.count_nonzero(dist_id_per_position == dist_id)
             chosen = np.random.choice(dist.index, hit_count, p=dist.values)
             chosen_trait_indices[dist_id_per_position == dist_id] = chosen

--- a/voxcell/voxel_data.py
+++ b/voxcell/voxel_data.py
@@ -430,7 +430,7 @@ def values_to_region_attribute(values, region_map, attr="acronym"):
 
 
 def values_to_hemisphere(values):
-    """Convert integer values 0, 1, 2 to "undefined", "right", "left" hemisphere labels.
+    """Convert integer values 0, 1, 2 to "undefined", "left" and "right" hemisphere labels.
 
     It can be used to convert the values retrieved with VoxelData.lookup.
 
@@ -446,7 +446,7 @@ def values_to_hemisphere(values):
     See Also:
         Scalar Image File Format in the documentation
     """
-    ids_map = {0: "undefined", 1: "right", 2: "left"}
+    ids_map = {0: "undefined", 1: "left", 2: "right"}
     ids, idx = np.unique(values, return_inverse=True)
     if not set(ids_map).issuperset(ids):
         raise VoxcellError(f"Invalid values, only {list(ids_map)} are allowed")


### PR DESCRIPTION
* Based on this: https://github.com/AllenInstitute/CCF_Tutorial/blob/63914f6c4b666428d3e2f2bd9b934519d23581dd/CCF_Tutorial.ipynb
    "We'll use a hemisphere id of 1 for the left hemisphere and 2 for the right."

The hierarchy file also contains hemisphere ids, but only '3' is used, likely to specify 'both'.