### PR TITLE
Update read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,7 @@ python:
       path: .
       extra_requirements:
         - docs
+
+build:
+  tools:
+    python: "3"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,5 +17,6 @@ python:
         - docs
 
 build:
+  os: ubuntu-22.04
   tools:
     python: "3"


### PR DESCRIPTION
So that python 3.7 isn't used by default