### PR TITLE
Fix warnings

### DIFF
--- a/tests/test_cell_collection.py
+++ b/tests/test_cell_collection.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
 from pandas.api.types import CategoricalDtype
-from pandas.api.types import is_categorical_dtype as is_cat
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 import voxcell.cell_collection as test_module
@@ -18,6 +17,10 @@ from voxcell import VoxcellError
 
 DATA_PATH = Path(__file__).parent / 'data'
 SONATA_DATA_PATH = DATA_PATH / 'sonata'
+
+
+def is_cat(series):
+    return isinstance(series.dtype, pd.CategoricalDtype)
 
 
 def euler_to_matrix(bank, attitude, heading):

--- a/voxcell/cell_collection.py
+++ b/voxcell/cell_collection.py
@@ -73,7 +73,7 @@ def _load_property(properties, name, values, library_group=None):
 
 def _is_string_enum(series):
     """Whether ``series`` contains enum of strings."""
-    is_cat_str = (pd.api.types.is_categorical_dtype(series) and
+    is_cat_str = (isinstance(series.dtype, pd.CategoricalDtype) and
                   series.dtype.categories.dtype == object)
     return series.dtype == object or is_cat_str
 

--- a/voxcell/voxel_data.py
+++ b/voxcell/voxel_data.py
@@ -56,7 +56,7 @@ class VoxelData:
     @property
     def voxel_volume(self):
         """Voxel volume."""
-        return abs(np.product(self.voxel_dimensions))
+        return abs(np.prod(self.voxel_dimensions))
 
     @property
     def ndim(self):


### PR DESCRIPTION
Fixes the following warnings:
```python
tests/test_cell_collection.py: 52 warnings
  /home/eleftherios/Projects/BBP/VOXCELL/voxcell/.tox/py3/lib/python3.10/site-packages/voxcell/cell_collection.py:76: FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead
    is_cat_str = (pd.api.types.is_categorical_dtype(series) and
```
and
```python
tests/test_voxel_data.py::test_volume
  /home/eleftherios/Projects/BBP/VOXCELL/voxcell/.tox/py3/lib/python3.10/site-packages/voxcell/voxel_data.py:249: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
    return self.count(values) * self.voxel_volume
```
